### PR TITLE
Fix DxSettings WinRT event wiring

### DIFF
--- a/UtilityHelpersLib/Helpers/Helpers.WinRt/Dx/DxSettings.cpp
+++ b/UtilityHelpersLib/Helpers/Helpers.WinRt/Dx/DxSettings.cpp
@@ -30,37 +30,39 @@ namespace Helpers {
             {
                 Platform::WeakReference weakRef = Platform::WeakReference(this);
 
-                this->dxSettings->GetDxSettingsHandlers()->msaaChanged.Add([weakRef] {
+                auto events = this->dxSettings->GetEvents();
+
+                this->eventSubscriptions.push_back(events->msaaChanged.Subscribe([weakRef] {
                     auto _this = weakRef.Resolve<DxSettings>();
                     if (!_this) return;
                     concurrency::create_async([=]() {
                         _this->MsaaChanged();
                         });
-                    });
+                    }));
 
-                this->dxSettings->GetDxSettingsHandlers()->vsyncChanged.Add([weakRef] {
+                this->eventSubscriptions.push_back(events->vsyncChanged.Subscribe([weakRef] {
                     auto _this = weakRef.Resolve<DxSettings>();
                     if (!_this) return;
                     concurrency::create_async([=]() {
                         _this->VSyncChanged();
                         });
-                    });
+                    }));
 
-                this->dxSettings->GetDxSettingsHandlers()->currentAdapterChanged.Add([weakRef] {
+                this->eventSubscriptions.push_back(events->currentAdapterChanged.Subscribe([weakRef] {
                     auto _this = weakRef.Resolve<DxSettings>();
                     if (!_this) return;
                     concurrency::create_async([=]() {
                         _this->CurrentAdapterChanged();
                         });
-                    });
+                    }));
 
-                this->dxSettings->GetDxSettingsHandlers()->adapersUpdated.Add([weakRef] {
+                this->eventSubscriptions.push_back(events->adapersUpdated.Subscribe([weakRef] {
                     auto _this = weakRef.Resolve<DxSettings>();
                     if (!_this) return;
                     concurrency::create_async([=]() {
                         _this->AdaptersUpdated();
                         });
-                    });
+                    }));
             }
 
             bool DxSettings::MSAA::get() {

--- a/UtilityHelpersLib/Helpers/Helpers.WinRt/Dx/DxSettings.h
+++ b/UtilityHelpersLib/Helpers/Helpers.WinRt/Dx/DxSettings.h
@@ -1,6 +1,8 @@
 ﻿#pragma once
 #include <Helpers/Dx/DxSettings.h>
+#include <Helpers/Event/IEvent.h>
 #include "Delegates.h"
+#include <vector>
 
 namespace Helpers {
     namespace WinRt {
@@ -66,6 +68,7 @@ namespace Helpers {
 
             private:
                 std::shared_ptr<H::Dx::DxSettings> dxSettings;
+                std::vector<std::shared_ptr<HELPERS_NS::Event::ISubscriptionToken>> eventSubscriptions;
             };
         }
     }


### PR DESCRIPTION
## Summary
- remove outdated GetDxSettingsHandlers usage in WinRT bridge and hook signals via DxSettings::GetEvents
- keep subscriptions alive to forward MSAA/VSync/adapter updates to WinRT events

## Testing
- not run (WinRT event wiring change only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942a653ea1483229c95aff1c938a9d8)