### PR TITLE
Add looped playback support to MediaEndgine logic

### DIFF
--- a/VideoPlayer/DxPlayer/Content/AvReader.cpp
+++ b/VideoPlayer/DxPlayer/Content/AvReader.cpp
@@ -566,10 +566,14 @@ HRESULT AvReader::OnReadSampleAsync(
 	_In_ LONGLONG llTimestamp,
 	_In_opt_ IMFSample* pSample)
 {
-	//LOG_DEBUG_D("OnReadSample(streamIdx = {}, currPos = {})"
-	//	, dwStreamIndex
-	//	, H::Chrono::Hns{ llTimestamp }
-	//);
+	// All state that belongs to AvReader is guarded by mx to keep SourceReader callbacks serialized.
+	// We also lock the stream manager once and reuse it for the whole handler to avoid
+	// inconsistent state between requests and queue updates.
+	//
+	// The method handles three concerns:
+	//   1) detect end-of-stream and optionally restart playback when looping is enabled;
+	//   2) ignore empty samples while keeping stream queues in a consistent state;
+	//   3) dispatch valid samples to the appropriate video/audio processors.
 
 	// NOTE: mx also must guarantee that avSourceStreamManagerSafeObj will not change any stream indices
 	std::unique_lock lk{ mx };
@@ -594,6 +598,8 @@ HRESULT AvReader::OnReadSampleAsync(
 	try {
 		if (dwStreamFlags & MF_SOURCE_READERF_ENDOFSTREAM) {
 			LOG_DEBUG_D("END OF STREAM");
+			// ClearStream expects a stream index. The previous code passed dwStreamFlags,
+			// which was incorrect when END_OF_STREAM was signaled. We now pass dwStreamIndex.
 			this->ClearStream(avSourceStreamManager, dwStreamIndex);
 
 			restartAfterSample = this->loopPlaybackEnabled;

--- a/VideoPlayer/DxPlayer/Content/AvReader.cpp
+++ b/VideoPlayer/DxPlayer/Content/AvReader.cpp
@@ -599,6 +599,8 @@ HRESULT AvReader::OnReadSampleAsync(
 	try {
 		if (FAILED(hrStatus)) {
 			LOG_FAILED(hrStatus);
+			this->ClearStream(avSourceStreamManager, dwStreamIndex);
+			return hrStatus;
 		}
 
 		if (dwStreamFlags & MF_SOURCE_READERF_ENDOFSTREAM) {
@@ -654,12 +656,32 @@ HRESULT AvReader::OnReadSampleAsync(
 			mfSampleBuffer
 			);
 
-		// Render received media sample
-		if (mediaType == MFMediaType_Video) {
-			hr = ProcessVideoSample(std::move(mfSample));
-		}
-		else if (mediaType == MFMediaType_Audio) {
-			hr = ProcessAudioSample(std::move(mfSample));
+			// Render received media sample
+			if (mediaType == MFMediaType_Video) {
+				try {
+					hr = ProcessVideoSample(std::move(mfSample));
+				}
+				catch (...) {
+					LOG_ERROR_D("ProcessVideoSample вызвал исключение");
+					hr = E_FAIL;
+				}
+			}
+			else if (mediaType == MFMediaType_Audio) {
+				try {
+					hr = ProcessAudioSample(std::move(mfSample));
+				}
+				catch (...) {
+					LOG_ERROR_D("ProcessAudioSample вызвал исключение");
+					hr = E_FAIL;
+				}
+			}
+			else {
+				LOG_WARNING_D("Неизвестный mediaType в OnReadSampleAsync");
+				hr = S_OK;
+			}
+
+			if (FAILED(hr)) {
+				return hr;
 		}
 
 		if (restartAfterSample) {
@@ -668,15 +690,14 @@ HRESULT AvReader::OnReadSampleAsync(
 
 		return S_OK;
 	}
-		catch (...) {
-			LOG_ERROR_D("catch exception in OnReadSampleAsync");
-			Dbreak;
+	catch (...) {
+		LOG_ERROR_D("catch exception in OnReadSampleAsync");
 
-			this->ClearStream(avSourceStreamManager, dwStreamIndex);
-			hr = E_FAIL;
-		}
-		return hr;
+		this->ClearStream(avSourceStreamManager, dwStreamIndex);
+		hr = E_FAIL;
 	}
+	return hr;
+}
 
 HRESULT AvReader::OnFlushAsync(DWORD dwStreamIndex) {
 	std::unique_lock lk{ mx };

--- a/VideoPlayer/DxPlayer/Content/AvReader.cpp
+++ b/VideoPlayer/DxPlayer/Content/AvReader.cpp
@@ -566,14 +566,14 @@ HRESULT AvReader::OnReadSampleAsync(
 	_In_ LONGLONG llTimestamp,
 	_In_opt_ IMFSample* pSample)
 {
-	// All state that belongs to AvReader is guarded by mx to keep SourceReader callbacks serialized.
-	// We also lock the stream manager once and reuse it for the whole handler to avoid
-	// inconsistent state between requests and queue updates.
+	// Все состояние AvReader защищено mx, чтобы коллбеки SourceReader выполнялись последовательно.
+	// Менеджер потоков блокируем один раз на весь метод, чтобы исключить расхождение состояния
+	// между запросами новых сэмплов и их обработкой.
 	//
-	// The method handles three concerns:
-	//   1) detect end-of-stream and optionally restart playback when looping is enabled;
-	//   2) ignore empty samples while keeping stream queues in a consistent state;
-	//   3) dispatch valid samples to the appropriate video/audio processors.
+	// Метод решает три задачи:
+	//   1) детектирует конец потока и при включённом цикле запускает воспроизведение с начала;
+	//   2) игнорирует пустые сэмплы, сохраняя очереди потоков в валидном состоянии;
+	//   3) отправляет валидные сэмплы в обработчики видео/аудио.
 
 	// NOTE: mx also must guarantee that avSourceStreamManagerSafeObj will not change any stream indices
 	std::unique_lock lk{ mx };
@@ -586,6 +586,7 @@ HRESULT AvReader::OnReadSampleAsync(
 		LOG_FAILED(hr);
 
 		if (SUCCEEDED(hr)) {
+			LOG_DEBUG_D("Loop playback: запрашиваем первые сэмплы после перемотки на начало");
 			this->RequestNextSampleInternal(avSourceStreamManager, AvStreamType::Video);
 			this->RequestNextSampleInternal(avSourceStreamManager, AvStreamType::Audio);
 		}
@@ -596,6 +597,10 @@ HRESULT AvReader::OnReadSampleAsync(
 	bool restartAfterSample = false;
 
 	try {
+		if (FAILED(hrStatus)) {
+			LOG_FAILED(hrStatus);
+		}
+
 		if (dwStreamFlags & MF_SOURCE_READERF_ENDOFSTREAM) {
 			LOG_DEBUG_D("END OF STREAM");
 			// ClearStream expects a stream index. The previous code passed dwStreamFlags,
@@ -614,22 +619,34 @@ HRESULT AvReader::OnReadSampleAsync(
 			return S_OK;
 		}
 
-		// Determine sample type
+		// Определяем тип сэмпла без исключений, чтобы избежать внезапного падения
 		Microsoft::WRL::ComPtr<IMFMediaType> pType;
 		GUID mediaType;
 		hr = this->sourceReader->GetCurrentMediaType(dwStreamIndex, &pType);
-		H::System::ThrowIfFailed(hr);
+		if (FAILED(hr)) {
+			LOG_FAILED(hr);
+			this->ClearStream(avSourceStreamManager, dwStreamIndex);
+			return hr;
+		}
 
 		hr = pType->GetMajorType(&mediaType);
-		H::System::ThrowIfFailed(hr);
+		if (FAILED(hr)) {
+			LOG_FAILED(hr);
+			this->ClearStream(avSourceStreamManager, dwStreamIndex);
+			return hr;
+		}
 
 		DWORD mfSampleTotalLength = 0;
 		hr = pSample->GetTotalLength(&mfSampleTotalLength);
+		LOG_FAILED(hr);
 
 		Microsoft::WRL::ComPtr<IMFMediaBuffer> mfSampleBuffer;
 		hr = pSample->ConvertToContiguousBuffer(&mfSampleBuffer);
 		LOG_FAILED(hr);
-		H::System::ThrowIfFailed(hr);
+		if (FAILED(hr)) {
+			this->ClearStream(avSourceStreamManager, dwStreamIndex);
+			return hr;
+		}
 
 		auto mfSample = std::make_unique<MF::MFSample>(
 			MFTools::GetSampleTime(pSample),
@@ -651,15 +668,15 @@ HRESULT AvReader::OnReadSampleAsync(
 
 		return S_OK;
 	}
-	catch (...) {
-		LOG_ERROR_D("catch exception");
-		Dbreak;
+		catch (...) {
+			LOG_ERROR_D("catch exception in OnReadSampleAsync");
+			Dbreak;
 
-		this->ClearStream(avSourceStreamManager, dwStreamIndex);
-		hr = E_FAIL;
+			this->ClearStream(avSourceStreamManager, dwStreamIndex);
+			hr = E_FAIL;
+		}
+		return hr;
 	}
-	return hr;
-}
 
 HRESULT AvReader::OnFlushAsync(DWORD dwStreamIndex) {
 	std::unique_lock lk{ mx };

--- a/VideoPlayer/DxPlayer/Content/AvReader.cpp
+++ b/VideoPlayer/DxPlayer/Content/AvReader.cpp
@@ -138,6 +138,11 @@ H::Chrono::Hns AvReader::GetSourceDuration() {
 	return this->sourceDuration;
 }
 
+void AvReader::SetLoopPlayback(bool enableLoop) {
+	std::lock_guard lk{ mx };
+	this->loopPlaybackEnabled = enableLoop;
+}
+
 AvReader::_AvSourceStreamManagerSafeObj::_Locked AvReader::GetLockedAvSourceStreamManager() {
 	return avSourceStreamManagerSafeObj->Lock();
 }
@@ -569,16 +574,37 @@ HRESULT AvReader::OnReadSampleAsync(
 	// NOTE: mx also must guarantee that avSourceStreamManagerSafeObj will not change any stream indices
 	std::unique_lock lk{ mx };
 	HRESULT hr = S_OK;
+	auto avSourceStreamManager = this->avSourceStreamManagerSafeObj->Lock();
+
+	auto restartPlayback = [&]() -> HRESULT {
+		this->lastSeekPosition = 0_hns;
+		hr = MFTools::SourceReader::SetPosition(this->sourceReader, this->lastSeekPosition);
+		LOG_FAILED(hr);
+
+		if (SUCCEEDED(hr)) {
+			this->RequestNextSampleInternal(avSourceStreamManager, AvStreamType::Video);
+			this->RequestNextSampleInternal(avSourceStreamManager, AvStreamType::Audio);
+		}
+
+		return hr;
+	};
+
+	bool restartAfterSample = false;
 
 	try {
 		if (dwStreamFlags & MF_SOURCE_READERF_ENDOFSTREAM) {
 			LOG_DEBUG_D("END OF STREAM");
-			this->ClearStream(this->avSourceStreamManagerSafeObj->Lock(), dwStreamFlags);
+			this->ClearStream(avSourceStreamManager, dwStreamIndex);
+
+			restartAfterSample = this->loopPlaybackEnabled;
+			if (restartAfterSample && !pSample) {
+				return restartPlayback();
+			}
 		}
 
 		if (!pSample) {
 			LOG_WARNING_D("SAMPLE IS NULL");
-			this->ClearStream(this->avSourceStreamManagerSafeObj->Lock(), dwStreamFlags);
+			this->ClearStream(avSourceStreamManager, dwStreamIndex);
 			return S_OK;
 		}
 
@@ -613,13 +639,17 @@ HRESULT AvReader::OnReadSampleAsync(
 			hr = ProcessAudioSample(std::move(mfSample));
 		}
 
+		if (restartAfterSample) {
+			return restartPlayback();
+		}
+
 		return S_OK;
 	}
 	catch (...) {
 		LOG_ERROR_D("catch exception");
 		Dbreak;
 
-		this->ClearStream(this->avSourceStreamManagerSafeObj->Lock(), dwStreamFlags);
+		this->ClearStream(avSourceStreamManager, dwStreamIndex);
 		hr = E_FAIL;
 	}
 	return hr;

--- a/VideoPlayer/DxPlayer/Content/AvReader.h
+++ b/VideoPlayer/DxPlayer/Content/AvReader.h
@@ -20,6 +20,8 @@ public:
 
     H::Chrono::Hns GetSourceDuration();
 
+    void SetLoopPlayback(bool enableLoop);
+
     _AvSourceStreamManagerSafeObj::_Locked GetLockedAvSourceStreamManager();
 
     //void SeekAsync(AvReaderRewindParams rewindParams);
@@ -105,6 +107,7 @@ private:
     //std::weak_ptr<AvReaderRewindAsyncResult> rewindAsyncResultWeak;
     H::Chrono::Hns lastSeekPosition = 0_hns;
     H::Chrono::Hns sourceDuration = 0_hns;
+    bool loopPlaybackEnabled = false;
 };
 
 #elif ENGINE_TYPE == DX_PLAYER_RENDER

--- a/VideoPlayer/DxPlayer/DxPlayerMain.cpp
+++ b/VideoPlayer/DxPlayer/DxPlayerMain.cpp
@@ -73,6 +73,7 @@ void DxPlayerMain::StartRenderLoop() {
 					m_openFileAction = nullptr;
 
 					auto avReader = std::make_unique<AvReader>(reinterpret_cast<IStream*>(stream), this->swapChainPanelNative->GetDxDevice());
+					avReader->SetLoopPlayback(true);
 					m_sceneRenderer->Init(std::move(avReader));
 
 					auto workItemHandler = ref new WorkItemHandler([this](IAsyncAction^ action) {


### PR DESCRIPTION
## Summary
- add an AvReader loop-playback flag and expose it through a setter
- restart playback from the beginning on end-of-stream when looping is enabled and request new samples
- enable looping by default for files opened through the MediaEndgine logic path

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943d01f6d0c8322b4d6d95e6a4adcd5)