### PR TITLE
Refine shared DXGI texture path for split devices

### DIFF
--- a/UtilityHelpersLib/Helpers/Helpers.Shared/Helpers/Dx/DxSharedTexture.cpp
+++ b/UtilityHelpersLib/Helpers/Helpers.Shared/Helpers/Dx/DxSharedTexture.cpp
@@ -95,6 +95,28 @@ namespace HELPERS_NS {
             }
         }
 
+        void DxSharedTexture::CopyFrom(const Microsoft::WRL::ComPtr<ID3D11Texture2D>& srcTexture) {
+            {
+                auto textureOnSrcDeviceLocked = this->GetLockedTextureOnSrcDevice();
+
+                Microsoft::WRL::ComPtr<ID3D11DeviceContext> srcDeviceContext;
+                srcDevice->GetImmediateContext(srcDeviceContext.GetAddressOf());
+
+                // Copy srcTexture that allocated on srcDevice to shared texture
+                srcDeviceContext->CopyResource(textureOnSrcDeviceLocked.GetTexture(), srcTexture.Get());
+            }
+
+            // Acquire/release on destination device to ensure the new content is visible.
+            {
+                auto textureOnDstDeviceLocked = this->GetLockedTextureOnDstDevice();
+                (void)textureOnDstDeviceLocked;
+            }
+        }
+
+        Microsoft::WRL::ComPtr<ID3D11Texture2D> DxSharedTexture::GetDstTexture() const {
+            return this->dstDeviceTexture;
+        }
+
 
         DxSharedTextureLocked::DxSharedTextureLocked(
             Microsoft::WRL::ComPtr<ID3D11Texture2D> tex,

--- a/UtilityHelpersLib/Helpers/Helpers.Shared/Helpers/Dx/DxSharedTexture.h
+++ b/UtilityHelpersLib/Helpers/Helpers.Shared/Helpers/Dx/DxSharedTexture.h
@@ -26,6 +26,9 @@ namespace HELPERS_NS {
             //DxSharedTextureLocker GetTextureOnSrcDevice() const;
             //DxSharedTextureLocker GetTextureOnDstDevice() const;
 
+            void CopyFrom(const Microsoft::WRL::ComPtr<ID3D11Texture2D>& srcTexture);
+            Microsoft::WRL::ComPtr<ID3D11Texture2D> GetDstTexture() const;
+
             void CopyTexture(
                 ID3D11Texture2D** ppDstTexture,
                 const Microsoft::WRL::ComPtr<ID3D11Texture2D>& srcTexture);

--- a/VideoPlayer/TestVideoPlayer/Sources/AvReaderDxgiEffect.cpp
+++ b/VideoPlayer/TestVideoPlayer/Sources/AvReaderDxgiEffect.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include "AvReaderDxgiEffect.h"
 #include <Helpers/System.h>
+#include <cstring>
 
 #if AvReaderDxgiManager_NEW_LOGIC
 AvReaderDxgiEffect::AvReaderDxgiEffect(IMFMediaType* input, H::Dx::DxDeviceSafeObj* dxDeviceSafeObj, Microsoft::WRL::ComPtr<IMFDXGIDeviceManager> mfDxgiDeviceManager)
@@ -38,24 +39,35 @@ std::unique_ptr<MF::MFVideoSample> AvReaderDxgiEffect::Process(std::unique_ptr<M
     hr = dxgiBuffer->GetResource(IID_PPV_ARGS(&mfSampleTexture));
     H::System::ThrowIfFailed(hr);
 
-    Microsoft::WRL::ComPtr<ID3D11Texture2D> dstTexture;
-    {
-        H::Dx::MFDXGIDeviceManagerLock mfDxgiDeviceManagerLock{ this->mfDxgiDeviceManager }; // it may block current thread when device lock / unlock
+    H::Dx::MFDXGIDeviceManagerLock mfDxgiDeviceManagerLock{ this->mfDxgiDeviceManager }; // it may block current thread when device lock / unlock
 
-        Microsoft::WRL::ComPtr<ID3D11Device> mfD3dDevice;
-        hr = mfDxgiDeviceManagerLock.LockDevice(mfD3dDevice.GetAddressOf());
-        if (FAILED(hr)) {
-            Dbreak;
-        }
-
-        D3D11_TEXTURE2D_DESC srcTextureDesc = {};
-        mfSampleTexture->GetDesc(&srcTextureDesc);
-
-        if (!this->sharedTexture) {
-            this->sharedTexture = std::make_unique<H::Dx::DxSharedTexture>(srcTextureDesc, this->dxDeviceSafeObj->Lock()->GetD3DDevice(), mfD3dDevice);
-        }
-        this->sharedTexture->CopyTexture(dstTexture.GetAddressOf(), mfSampleTexture);
+    Microsoft::WRL::ComPtr<ID3D11Device> mfD3dDevice;
+    hr = mfDxgiDeviceManagerLock.LockDevice(mfD3dDevice.GetAddressOf());
+    if (FAILED(hr)) {
+        Dbreak;
     }
+
+    D3D11_TEXTURE2D_DESC srcTextureDesc = {};
+    mfSampleTexture->GetDesc(&srcTextureDesc);
+
+    // Recreate pool if description changed or not initialized.
+    if (this->sharedTextures.empty() || memcmp(&this->sharedTextureDesc, &srcTextureDesc, sizeof(D3D11_TEXTURE2D_DESC)) != 0) {
+        this->sharedTextures.clear();
+        this->sharedTextureCursor = 0;
+        this->sharedTextureDesc = srcTextureDesc;
+
+        constexpr size_t poolSize = 3;
+        auto renderDevice = this->dxDeviceSafeObj->Lock()->GetD3DDevice();
+        for (size_t i = 0; i < poolSize; ++i) {
+            this->sharedTextures.push_back(std::make_unique<H::Dx::DxSharedTexture>(srcTextureDesc, renderDevice, mfD3dDevice));
+        }
+    }
+
+    auto& sharedTexture = *this->sharedTextures[this->sharedTextureCursor];
+    this->sharedTextureCursor = (this->sharedTextureCursor + 1) % this->sharedTextures.size();
+
+    sharedTexture.CopyFrom(mfSampleTexture);
+    auto dstTexture = sharedTexture.GetDstTexture();
 
     MF::MFSample mfSampleCopy = *mfSample;
     mfSampleCopy.buffer = nullptr; // release original reference to IMFSample

--- a/VideoPlayer/TestVideoPlayer/Sources/AvReaderDxgiEffect.cpp
+++ b/VideoPlayer/TestVideoPlayer/Sources/AvReaderDxgiEffect.cpp
@@ -57,11 +57,8 @@ std::unique_ptr<MF::MFVideoSample> AvReaderDxgiEffect::Process(std::unique_ptr<M
         this->sharedTextureDesc = srcTextureDesc;
 
         constexpr size_t poolSize = 3;
-        auto renderDevice = this->dxDeviceSafeObj->Lock()->GetD3DDevice();
-        this->renderTextures.clear();
-        this->renderTextures.resize(poolSize);
         for (size_t i = 0; i < poolSize; ++i) {
-            this->sharedTextures.push_back(std::make_unique<H::Dx::DxSharedTexture>(srcTextureDesc, renderDevice, mfD3dDevice));
+            this->sharedTextures.push_back(std::make_unique<H::Dx::DxSharedTexture>(srcTextureDesc, this->dxDeviceSafeObj->Lock()->GetD3DDevice(), mfD3dDevice));
         }
     }
 
@@ -70,22 +67,7 @@ std::unique_ptr<MF::MFVideoSample> AvReaderDxgiEffect::Process(std::unique_ptr<M
     this->sharedTextureCursor = (this->sharedTextureCursor + 1) % this->sharedTextures.size();
 
     sharedTexture.CopyFrom(mfSampleTexture);
-
-    auto renderDevice = this->dxDeviceSafeObj->Lock();
-    Microsoft::WRL::ComPtr<ID3D11DeviceContext> d3dCtx;
-    renderDevice->GetD3DDevice()->GetImmediateContext(d3dCtx.GetAddressOf());
-
-    // Ensure we have a renderable copy on the render device without keyed mutex requirements.
-    auto& dstTexture = this->renderTextures[poolIndex];
-    if (!dstTexture) {
-        hr = renderDevice->GetD3DDevice()->CreateTexture2D(&this->sharedTextureDesc, nullptr, dstTexture.GetAddressOf());
-        H::System::ThrowIfFailed(hr);
-    }
-
-    {
-        auto lockedDstShared = sharedTexture.GetLockedTextureOnDstDevice();
-        d3dCtx->CopyResource(dstTexture.Get(), lockedDstShared.GetTexture());
-    }
+    auto dstTexture = sharedTexture.GetDstTexture();
 
     MF::MFSample mfSampleCopy = *mfSample;
     mfSampleCopy.buffer = nullptr; // release original reference to IMFSample

--- a/VideoPlayer/TestVideoPlayer/Sources/AvReaderDxgiEffect.cpp
+++ b/VideoPlayer/TestVideoPlayer/Sources/AvReaderDxgiEffect.cpp
@@ -72,8 +72,8 @@ std::unique_ptr<MF::MFVideoSample> AvReaderDxgiEffect::Process(std::unique_ptr<M
     sharedTexture.CopyFrom(mfSampleTexture);
 
     auto renderDevice = this->dxDeviceSafeObj->Lock();
-    auto renderDeviceCtx = renderDevice->LockContext();
-    auto d3dCtx = renderDeviceCtx->D3D();
+    Microsoft::WRL::ComPtr<ID3D11DeviceContext> d3dCtx;
+    renderDevice->GetD3DDevice()->GetImmediateContext(d3dCtx.GetAddressOf());
 
     // Ensure we have a renderable copy on the render device without keyed mutex requirements.
     auto& dstTexture = this->renderTextures[poolIndex];

--- a/VideoPlayer/TestVideoPlayer/Sources/AvReaderDxgiEffect.cpp
+++ b/VideoPlayer/TestVideoPlayer/Sources/AvReaderDxgiEffect.cpp
@@ -58,6 +58,8 @@ std::unique_ptr<MF::MFVideoSample> AvReaderDxgiEffect::Process(std::unique_ptr<M
 
         constexpr size_t poolSize = 3;
         auto renderDevice = this->dxDeviceSafeObj->Lock()->GetD3DDevice();
+        this->renderTextures.clear();
+        this->renderTextures.resize(poolSize);
         for (size_t i = 0; i < poolSize; ++i) {
             this->sharedTextures.push_back(std::make_unique<H::Dx::DxSharedTexture>(srcTextureDesc, renderDevice, mfD3dDevice));
         }
@@ -67,7 +69,21 @@ std::unique_ptr<MF::MFVideoSample> AvReaderDxgiEffect::Process(std::unique_ptr<M
     this->sharedTextureCursor = (this->sharedTextureCursor + 1) % this->sharedTextures.size();
 
     sharedTexture.CopyFrom(mfSampleTexture);
-    auto dstTexture = sharedTexture.GetDstTexture();
+
+    auto renderDevice = this->dxDeviceSafeObj->Lock();
+    auto renderDeviceContext = renderDevice->GetD3DDeviceContext();
+
+    // Ensure we have a renderable copy on the render device without keyed mutex requirements.
+    auto& dstTexture = this->renderTextures[this->sharedTextureCursor];
+    if (!dstTexture) {
+        hr = renderDevice->GetD3DDevice()->CreateTexture2D(&this->sharedTextureDesc, nullptr, dstTexture.GetAddressOf());
+        H::System::ThrowIfFailed(hr);
+    }
+
+    {
+        auto lockedDstShared = sharedTexture.GetLockedTextureOnDstDevice();
+        renderDeviceContext->CopyResource(dstTexture.Get(), lockedDstShared.GetTexture());
+    }
 
     MF::MFSample mfSampleCopy = *mfSample;
     mfSampleCopy.buffer = nullptr; // release original reference to IMFSample

--- a/VideoPlayer/TestVideoPlayer/Sources/AvReaderDxgiEffect.cpp
+++ b/VideoPlayer/TestVideoPlayer/Sources/AvReaderDxgiEffect.cpp
@@ -65,16 +65,18 @@ std::unique_ptr<MF::MFVideoSample> AvReaderDxgiEffect::Process(std::unique_ptr<M
         }
     }
 
-    auto& sharedTexture = *this->sharedTextures[this->sharedTextureCursor];
+    const size_t poolIndex = this->sharedTextureCursor;
+    auto& sharedTexture = *this->sharedTextures[poolIndex];
     this->sharedTextureCursor = (this->sharedTextureCursor + 1) % this->sharedTextures.size();
 
     sharedTexture.CopyFrom(mfSampleTexture);
 
     auto renderDevice = this->dxDeviceSafeObj->Lock();
-    auto renderDeviceContext = renderDevice->GetD3DDeviceContext();
+    auto renderDeviceCtx = renderDevice->LockContext();
+    auto d3dCtx = renderDeviceCtx->D3D();
 
     // Ensure we have a renderable copy on the render device without keyed mutex requirements.
-    auto& dstTexture = this->renderTextures[this->sharedTextureCursor];
+    auto& dstTexture = this->renderTextures[poolIndex];
     if (!dstTexture) {
         hr = renderDevice->GetD3DDevice()->CreateTexture2D(&this->sharedTextureDesc, nullptr, dstTexture.GetAddressOf());
         H::System::ThrowIfFailed(hr);
@@ -82,7 +84,7 @@ std::unique_ptr<MF::MFVideoSample> AvReaderDxgiEffect::Process(std::unique_ptr<M
 
     {
         auto lockedDstShared = sharedTexture.GetLockedTextureOnDstDevice();
-        renderDeviceContext->CopyResource(dstTexture.Get(), lockedDstShared.GetTexture());
+        d3dCtx->CopyResource(dstTexture.Get(), lockedDstShared.GetTexture());
     }
 
     MF::MFSample mfSampleCopy = *mfSample;

--- a/VideoPlayer/TestVideoPlayer/Sources/AvReaderDxgiEffect.h
+++ b/VideoPlayer/TestVideoPlayer/Sources/AvReaderDxgiEffect.h
@@ -4,8 +4,9 @@
 #include <Helpers/Dx/DxSharedTexture.h>
 #include <Helpers/Dx/DxgiDeviceLock.h>
 #include <Helpers/Dx/DxDevice.h>
+#include <vector>
 
-#define AvReaderDxgiManager_NEW_LOGIC 0
+#define AvReaderDxgiManager_NEW_LOGIC 1
 
 class AvReaderDxgiEffect : public IAvReaderEffect {
 public:
@@ -22,6 +23,9 @@ private:
     H::Dx::DxDeviceSafeObj* dxDeviceSafeObj;
 #if AvReaderDxgiManager_NEW_LOGIC
     Microsoft::WRL::ComPtr<IMFDXGIDeviceManager> mfDxgiDeviceManager;
+    std::vector<std::unique_ptr<H::Dx::DxSharedTexture>> sharedTextures;
+    size_t sharedTextureCursor = 0;
+    D3D11_TEXTURE2D_DESC sharedTextureDesc = {};
 #endif
     std::unique_ptr<H::Dx::DxSharedTexture> sharedTexture;
     DirectX::XMUINT2 videoSize;

--- a/VideoPlayer/TestVideoPlayer/Sources/AvReaderDxgiEffect.h
+++ b/VideoPlayer/TestVideoPlayer/Sources/AvReaderDxgiEffect.h
@@ -26,6 +26,8 @@ private:
     std::vector<std::unique_ptr<H::Dx::DxSharedTexture>> sharedTextures;
     size_t sharedTextureCursor = 0;
     D3D11_TEXTURE2D_DESC sharedTextureDesc = {};
+
+    std::vector<Microsoft::WRL::ComPtr<ID3D11Texture2D>> renderTextures;
 #endif
     std::unique_ptr<H::Dx::DxSharedTexture> sharedTexture;
     DirectX::XMUINT2 videoSize;

--- a/VideoPlayer/TestVideoPlayer/Sources/AvReaderDxgiEffect.h
+++ b/VideoPlayer/TestVideoPlayer/Sources/AvReaderDxgiEffect.h
@@ -26,8 +26,6 @@ private:
     std::vector<std::unique_ptr<H::Dx::DxSharedTexture>> sharedTextures;
     size_t sharedTextureCursor = 0;
     D3D11_TEXTURE2D_DESC sharedTextureDesc = {};
-
-    std::vector<Microsoft::WRL::ComPtr<ID3D11Texture2D>> renderTextures;
 #endif
     std::unique_ptr<H::Dx::DxSharedTexture> sharedTexture;
     DirectX::XMUINT2 videoSize;


### PR DESCRIPTION
## Summary
- enable the split-device DXGI path for TestVideoPlayer
- reuse a small pool of shared textures to avoid per-frame creation and extra copies
- add helper APIs to copy into shared textures and expose the render-side resource

## Testing
- Not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694541faa2188322a2440c4f36a66c04)