### PR TITLE
Optimize TestVideoPlayer DXGI shared texture path

### DIFF
--- a/UtilityHelpersLib/Helpers/Helpers.Shared/Helpers/Dx/DxSharedTexture.cpp
+++ b/UtilityHelpersLib/Helpers/Helpers.Shared/Helpers/Dx/DxSharedTexture.cpp
@@ -78,20 +78,15 @@ namespace HELPERS_NS {
                 srcDeviceContext->CopyResource(textureOnSrcDeviceLocked.GetTexture(), srcTexture.Get());
             }
 
-            {
+            if (ppDstTexture) {
                 auto textureOnDstDeviceLocked = this->GetLockedTextureOnDstDevice();
 
-                D3D11_TEXTURE2D_DESC srcTextureDesc = {};
-                srcTexture->GetDesc(&srcTextureDesc);
-            
-                hr = this->dstDevice->CreateTexture2D(&srcTextureDesc, nullptr, ppDstTexture);
-                HELPERS_NS::System::ThrowIfFailed(hr);
-
-                Microsoft::WRL::ComPtr<ID3D11DeviceContext> dstDeviceContext;
-                this->dstDevice->GetImmediateContext(dstDeviceContext.GetAddressOf());
-
-                // Copy from shared texture to dstTexture
-                dstDeviceContext->CopyResource(*ppDstTexture, textureOnDstDeviceLocked.GetTexture());
+                // Reuse the existing shared texture on the destination device instead of
+                // creating a new texture on every frame. The keyed mutex guarantees that
+                // the copy above is complete before the texture is handed off to the
+                // consumer.
+                *ppDstTexture = textureOnDstDeviceLocked.GetTexture();
+                (*ppDstTexture)->AddRef();
             }
         }
 

--- a/VideoPlayer/TestVideoPlayer/Sources/AvReaderDxgiEffect.cpp
+++ b/VideoPlayer/TestVideoPlayer/Sources/AvReaderDxgiEffect.cpp
@@ -38,9 +38,11 @@ std::unique_ptr<MF::MFVideoSample> AvReaderDxgiEffect::Process(std::unique_ptr<M
     hr = dxgiBuffer->GetResource(IID_PPV_ARGS(&mfSampleTexture));
     H::System::ThrowIfFailed(hr);
 
-    Microsoft::WRL::ComPtr<ID3D11Texture2D> dstTexture;
+    Microsoft::WRL::ComPtr<ID3D11Texture2D> sharedTextureOnRenderDevice;
     {
-        H::Dx::MFDXGIDeviceManagerLock mfDxgiDeviceManagerLock{ this->mfDxgiDeviceManager }; // it may block current thread when device lock / unlock
+        // NOTE: This lock is required to access the Media Foundation DXGI device,
+        // but should be held for a minimal time to avoid blocking the render thread.
+        H::Dx::MFDXGIDeviceManagerLock mfDxgiDeviceManagerLock{ this->mfDxgiDeviceManager };
 
         Microsoft::WRL::ComPtr<ID3D11Device> mfD3dDevice;
         hr = mfDxgiDeviceManagerLock.LockDevice(mfD3dDevice.GetAddressOf());
@@ -52,14 +54,19 @@ std::unique_ptr<MF::MFVideoSample> AvReaderDxgiEffect::Process(std::unique_ptr<M
         mfSampleTexture->GetDesc(&srcTextureDesc);
 
         if (!this->sharedTexture) {
+            // Create a keyed-mutex shared texture once and reuse it across frames so that
+            // the render device can read directly without an extra per-frame copy or
+            // texture creation.
             this->sharedTexture = std::make_unique<H::Dx::DxSharedTexture>(srcTextureDesc, this->dxDeviceSafeObj->Lock()->GetD3DDevice(), mfD3dDevice);
         }
-        this->sharedTexture->CopyTexture(dstTexture.GetAddressOf(), mfSampleTexture);
+
+        // Copies only into the shared texture and returns the render-device view.
+        this->sharedTexture->CopyTexture(sharedTextureOnRenderDevice.GetAddressOf(), mfSampleTexture);
     }
 
     MF::MFSample mfSampleCopy = *mfSample;
     mfSampleCopy.buffer = nullptr; // release original reference to IMFSample
-    auto sample = std::make_unique<MF::MFVideoSample>(mfSampleCopy, dstTexture);
+    auto sample = std::make_unique<MF::MFVideoSample>(mfSampleCopy, sharedTextureOnRenderDevice);
     return sample;
 
 #else

--- a/VideoPlayer/TestVideoPlayer/Sources/AvReaderDxgiEffect.h
+++ b/VideoPlayer/TestVideoPlayer/Sources/AvReaderDxgiEffect.h
@@ -5,7 +5,7 @@
 #include <Helpers/Dx/DxgiDeviceLock.h>
 #include <Helpers/Dx/DxDevice.h>
 
-#define AvReaderDxgiManager_NEW_LOGIC 0
+#define AvReaderDxgiManager_NEW_LOGIC 1
 
 class AvReaderDxgiEffect : public IAvReaderEffect {
 public:


### PR DESCRIPTION
## Summary
- enable the new DXGI shared-texture logic for TestVideoPlayer and reuse the shared keyed-mutex texture instead of allocating per frame
- return the render-device view of the shared texture to avoid extra copy operations
- update the shared texture helper to hand back the existing shared texture rather than creating a new destination texture each frame

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69458d150bd48322bc8c59f2e08ffdb7)