### PR TITLE
Optimize shared DXGI video sample handling

### DIFF
--- a/UtilityHelpersLib/Helpers/Helpers.Shared/Helpers/Dx/DxSharedTexture.cpp
+++ b/UtilityHelpersLib/Helpers/Helpers.Shared/Helpers/Dx/DxSharedTexture.cpp
@@ -54,6 +54,19 @@ namespace HELPERS_NS {
         DxSharedTextureLocked DxSharedTexture::GetLockedTextureOnSrcDevice() const {
             return DxSharedTextureLocked(this->srcDeviceTexture, this->srcDeviceTextureMtx);
         }
+        DxSharedTextureLocked DxSharedTexture::LockDstTexture() const {
+            return this->GetLockedTextureOnDstDevice();
+        }
+        void DxSharedTexture::CopyFromSource(
+            const Microsoft::WRL::ComPtr<ID3D11Texture2D>& srcTexture) {
+            auto textureOnSrcDeviceLocked = this->GetLockedTextureOnSrcDevice();
+
+            Microsoft::WRL::ComPtr<ID3D11DeviceContext> srcDeviceContext;
+            srcDevice->GetImmediateContext(srcDeviceContext.GetAddressOf());
+
+            // Copy srcTexture that allocated on srcDevice to shared texture
+            srcDeviceContext->CopyResource(textureOnSrcDeviceLocked.GetTexture(), srcTexture.Get());
+        }
         //DxSharedTextureLocker DxSharedTexture::GetTextureOnSrcDevice() const {
         //    return DxSharedTextureLocker(this->dstDeviceTexture, this->dstDeviceTextureMtx);
         //}
@@ -68,15 +81,7 @@ namespace HELPERS_NS {
             const Microsoft::WRL::ComPtr<ID3D11Texture2D>& srcTexture)
         {
             HRESULT hr = S_OK;
-            {
-                auto textureOnSrcDeviceLocked = this->GetLockedTextureOnSrcDevice();
-
-                Microsoft::WRL::ComPtr<ID3D11DeviceContext> srcDeviceContext;
-                srcDevice->GetImmediateContext(srcDeviceContext.GetAddressOf());
-
-                // Copy srcTexture that allocated on srcDevice to shared texture
-                srcDeviceContext->CopyResource(textureOnSrcDeviceLocked.GetTexture(), srcTexture.Get());
-            }
+            this->CopyFromSource(srcTexture);
 
             {
                 auto textureOnDstDeviceLocked = this->GetLockedTextureOnDstDevice();

--- a/UtilityHelpersLib/Helpers/Helpers.Shared/Helpers/Dx/DxSharedTexture.h
+++ b/UtilityHelpersLib/Helpers/Helpers.Shared/Helpers/Dx/DxSharedTexture.h
@@ -23,6 +23,8 @@ namespace HELPERS_NS {
 
             DxSharedTextureLocked GetLockedTextureOnDstDevice() const;
             DxSharedTextureLocked GetLockedTextureOnSrcDevice() const;
+            DxSharedTextureLocked LockDstTexture() const;
+            void CopyFromSource(const Microsoft::WRL::ComPtr<ID3D11Texture2D>& srcTexture);
             //DxSharedTextureLocker GetTextureOnSrcDevice() const;
             //DxSharedTextureLocker GetTextureOnDstDevice() const;
 
@@ -46,6 +48,10 @@ namespace HELPERS_NS {
             DxSharedTextureLocked(
                 Microsoft::WRL::ComPtr<ID3D11Texture2D> tex,
                 Microsoft::WRL::ComPtr<IDXGIKeyedMutex> texMtx);
+            DxSharedTextureLocked(const DxSharedTextureLocked&) = delete;
+            DxSharedTextureLocked& operator=(const DxSharedTextureLocked&) = delete;
+            DxSharedTextureLocked(DxSharedTextureLocked&&) = default;
+            DxSharedTextureLocked& operator=(DxSharedTextureLocked&&) = default;
             ~DxSharedTextureLocked();
 
             ID3D11Texture2D* GetTexture() const;

--- a/VideoPlayer/TestVideoPlayer/Sources/AvReaderDxgiEffect.cpp
+++ b/VideoPlayer/TestVideoPlayer/Sources/AvReaderDxgiEffect.cpp
@@ -38,7 +38,6 @@ std::unique_ptr<MF::MFVideoSample> AvReaderDxgiEffect::Process(std::unique_ptr<M
     hr = dxgiBuffer->GetResource(IID_PPV_ARGS(&mfSampleTexture));
     H::System::ThrowIfFailed(hr);
 
-    Microsoft::WRL::ComPtr<ID3D11Texture2D> dstTexture;
     {
         H::Dx::MFDXGIDeviceManagerLock mfDxgiDeviceManagerLock{ this->mfDxgiDeviceManager }; // it may block current thread when device lock / unlock
 
@@ -54,12 +53,18 @@ std::unique_ptr<MF::MFVideoSample> AvReaderDxgiEffect::Process(std::unique_ptr<M
         if (!this->sharedTexture) {
             this->sharedTexture = std::make_unique<H::Dx::DxSharedTexture>(srcTextureDesc, this->dxDeviceSafeObj->Lock()->GetD3DDevice(), mfD3dDevice);
         }
-        this->sharedTexture->CopyTexture(dstTexture.GetAddressOf(), mfSampleTexture);
+        this->sharedTexture->CopyFromSource(mfSampleTexture);
     }
+
+    auto lockedTexture = this->sharedTexture->LockDstTexture();
+    Microsoft::WRL::ComPtr<ID3D11Texture2D> dstTexture = lockedTexture.GetTexture();
 
     MF::MFSample mfSampleCopy = *mfSample;
     mfSampleCopy.buffer = nullptr; // release original reference to IMFSample
-    auto sample = std::make_unique<MF::MFVideoSample>(mfSampleCopy, dstTexture);
+    auto sample = std::make_unique<MF::MFVideoSample>(
+        mfSampleCopy,
+        dstTexture,
+        std::make_unique<H::Dx::DxSharedTextureLocked>(std::move(lockedTexture)));
     return sample;
 
 #else
@@ -72,7 +77,23 @@ std::unique_ptr<MF::MFVideoSample> AvReaderDxgiEffect::Process(std::unique_ptr<M
     hr = dxgiBuffer->GetResource(IID_PPV_ARGS(&mfSampleTexture));
     H::System::ThrowIfFailed(hr);
 
-    auto sample = std::make_unique<MF::MFVideoSample>(*mfSample, mfSampleTexture);
+    if (!this->sharedTexture) {
+        D3D11_TEXTURE2D_DESC srcTextureDesc = {};
+        mfSampleTexture->GetDesc(&srcTextureDesc);
+        this->sharedTexture = std::make_unique<H::Dx::DxSharedTexture>(
+            srcTextureDesc,
+            this->dxDeviceSafeObj->Lock()->GetD3DDevice(),
+            this->dxDeviceSafeObj->Lock()->GetD3DDevice());
+    }
+
+    this->sharedTexture->CopyFromSource(mfSampleTexture);
+    auto lockedTexture = this->sharedTexture->LockDstTexture();
+    Microsoft::WRL::ComPtr<ID3D11Texture2D> dstTexture = lockedTexture.GetTexture();
+
+    auto sample = std::make_unique<MF::MFVideoSample>(
+        *mfSample,
+        dstTexture,
+        std::make_unique<H::Dx::DxSharedTextureLocked>(std::move(lockedTexture)));
     return sample;
 #endif
 }

--- a/VideoPlayer/TestVideoPlayer/Sources/AvReaderDxgiEffect.h
+++ b/VideoPlayer/TestVideoPlayer/Sources/AvReaderDxgiEffect.h
@@ -5,7 +5,7 @@
 #include <Helpers/Dx/DxgiDeviceLock.h>
 #include <Helpers/Dx/DxDevice.h>
 
-#define AvReaderDxgiManager_NEW_LOGIC 0
+#define AvReaderDxgiManager_NEW_LOGIC 1
 
 class AvReaderDxgiEffect : public IAvReaderEffect {
 public:

--- a/VideoPlayer/TestVideoPlayer/Sources/MediaSample.h
+++ b/VideoPlayer/TestVideoPlayer/Sources/MediaSample.h
@@ -5,6 +5,18 @@
 #include <mfobjects.h>
 #include <d3d11.h>
 #include <wrl.h>
+#include <memory>
+
+namespace HELPERS_NS {
+    namespace Dx {
+        class DxSharedTextureLocked;
+    }
+}
+namespace H {
+    namespace Dx {
+        class DxSharedTextureLocked;
+    }
+}
 
 namespace MEDIA_FOUNDATION_NS {
     class MFSampleDataAccessor {
@@ -70,10 +82,15 @@ namespace MEDIA_FOUNDATION_NS {
     };
 
     struct MFVideoSample : MFSample {
+        std::unique_ptr<H::Dx::DxSharedTextureLocked> sharedTextureLock;
         Microsoft::WRL::ComPtr<ID3D11Texture2D> texture;
 
-        MFVideoSample(const MFSample& mfSample, Microsoft::WRL::ComPtr<ID3D11Texture2D> texture)
+        MFVideoSample(
+            const MFSample& mfSample,
+            Microsoft::WRL::ComPtr<ID3D11Texture2D> texture,
+            std::unique_ptr<H::Dx::DxSharedTextureLocked> sharedTextureLock = nullptr)
             : MFSample{ mfSample }
+            , sharedTextureLock{ std::move(sharedTextureLock) }
             , texture{ texture } {
         }
     };


### PR DESCRIPTION
## Summary
- enable the new AvReader DXGI logic and update shared texture handling to lock and reuse textures instead of creating new ones per frame
- extend shared texture helper with move-only locking helpers to keep keyed mutex ownership with each sample
- keep video sample keyed-mutex locks alive alongside textures to avoid extra copies during rendering

## Testing
- Not run (not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69458d150bd48322bc8c59f2e08ffdb7)