### PR TITLE
Use shared keyed textures for video frames

### DIFF
--- a/UtilityHelpersLib/Helpers/Helpers.Shared/Helpers/Dx/DxSharedTexture.cpp
+++ b/UtilityHelpersLib/Helpers/Helpers.Shared/Helpers/Dx/DxSharedTexture.cpp
@@ -48,11 +48,24 @@ namespace HELPERS_NS {
             return this->sharedTextureHandle != nullptr;
         }
 
-        DxSharedTextureLocked DxSharedTexture::GetLockedTextureOnDstDevice() const {
-            return DxSharedTextureLocked(this->dstDeviceTexture, this->dstDeviceTextureMtx);
+        DxSharedTextureLocked DxSharedTexture::GetLockedTextureOnDstDevice(UINT acquireKey, UINT releaseKey) const {
+            return DxSharedTextureLocked(this->dstDeviceTexture, this->dstDeviceTextureMtx, acquireKey, releaseKey);
         }
-        DxSharedTextureLocked DxSharedTexture::GetLockedTextureOnSrcDevice() const {
-            return DxSharedTextureLocked(this->srcDeviceTexture, this->srcDeviceTextureMtx);
+        DxSharedTextureLocked DxSharedTexture::GetLockedTextureOnSrcDevice(UINT acquireKey, UINT releaseKey) const {
+            return DxSharedTextureLocked(this->srcDeviceTexture, this->srcDeviceTextureMtx, acquireKey, releaseKey);
+        }
+
+        void DxSharedTexture::WriteToSharedTexture(
+            const Microsoft::WRL::ComPtr<ID3D11Texture2D>& srcTexture,
+            UINT acquireKey,
+            UINT releaseKey)
+        {
+            auto textureOnSrcDeviceLocked = this->GetLockedTextureOnSrcDevice(acquireKey, releaseKey);
+
+            Microsoft::WRL::ComPtr<ID3D11DeviceContext> srcDeviceContext;
+            srcDevice->GetImmediateContext(srcDeviceContext.GetAddressOf());
+
+            srcDeviceContext->CopyResource(textureOnSrcDeviceLocked.GetTexture(), srcTexture.Get());
         }
         //DxSharedTextureLocker DxSharedTexture::GetTextureOnSrcDevice() const {
         //    return DxSharedTextureLocker(this->dstDeviceTexture, this->dstDeviceTextureMtx);
@@ -98,16 +111,19 @@ namespace HELPERS_NS {
 
         DxSharedTextureLocked::DxSharedTextureLocked(
             Microsoft::WRL::ComPtr<ID3D11Texture2D> tex,
-            Microsoft::WRL::ComPtr<IDXGIKeyedMutex> texMtx) 
+            Microsoft::WRL::ComPtr<IDXGIKeyedMutex> texMtx,
+            UINT acquireKey,
+            UINT releaseKey) 
             : tex(tex)
             , texMtx(texMtx)
+            , releaseKey(releaseKey)
         {
-            HRESULT hr = this->texMtx->AcquireSync(0, INFINITE);
+            HRESULT hr = this->texMtx->AcquireSync(acquireKey, INFINITE);
             H::System::ThrowIfFailed(hr);
         }
 
         DxSharedTextureLocked::~DxSharedTextureLocked() {
-            HRESULT hr = this->texMtx->ReleaseSync(0);
+            HRESULT hr = this->texMtx->ReleaseSync(this->releaseKey);
             H::System::ThrowIfFailed(hr);
         }
 

--- a/UtilityHelpersLib/Helpers/Helpers.Shared/Helpers/Dx/DxSharedTexture.h
+++ b/UtilityHelpersLib/Helpers/Helpers.Shared/Helpers/Dx/DxSharedTexture.h
@@ -21,8 +21,15 @@ namespace HELPERS_NS {
 
             explicit operator bool() const;
 
-            DxSharedTextureLocked GetLockedTextureOnDstDevice() const;
-            DxSharedTextureLocked GetLockedTextureOnSrcDevice() const;
+            DxSharedTextureLocked GetLockedTextureOnDstDevice(UINT acquireKey = 0, UINT releaseKey = 0) const;
+            DxSharedTextureLocked GetLockedTextureOnSrcDevice(UINT acquireKey = 0, UINT releaseKey = 0) const;
+            void WriteToSharedTexture(
+                const Microsoft::WRL::ComPtr<ID3D11Texture2D>& srcTexture,
+                UINT acquireKey = 0,
+                UINT releaseKey = 1);
+
+            Microsoft::WRL::ComPtr<ID3D11Texture2D> GetDstTexture() const { return this->dstDeviceTexture; }
+            Microsoft::WRL::ComPtr<IDXGIKeyedMutex> GetDstKeyedMutex() const { return this->dstDeviceTextureMtx; }
             //DxSharedTextureLocker GetTextureOnSrcDevice() const;
             //DxSharedTextureLocker GetTextureOnDstDevice() const;
 
@@ -45,7 +52,9 @@ namespace HELPERS_NS {
         public:
             DxSharedTextureLocked(
                 Microsoft::WRL::ComPtr<ID3D11Texture2D> tex,
-                Microsoft::WRL::ComPtr<IDXGIKeyedMutex> texMtx);
+                Microsoft::WRL::ComPtr<IDXGIKeyedMutex> texMtx,
+                UINT acquireKey,
+                UINT releaseKey);
             ~DxSharedTextureLocked();
 
             ID3D11Texture2D* GetTexture() const;
@@ -53,6 +62,7 @@ namespace HELPERS_NS {
         private:
             Microsoft::WRL::ComPtr<ID3D11Texture2D> tex;
             Microsoft::WRL::ComPtr<IDXGIKeyedMutex> texMtx;
+            UINT releaseKey = 0;
         };
 
         // allows use texture only when texture mutex is locked

--- a/VideoPlayer/TestVideoPlayer/Sources/AvReaderDxgiEffect.cpp
+++ b/VideoPlayer/TestVideoPlayer/Sources/AvReaderDxgiEffect.cpp
@@ -38,28 +38,29 @@ std::unique_ptr<MF::MFVideoSample> AvReaderDxgiEffect::Process(std::unique_ptr<M
     hr = dxgiBuffer->GetResource(IID_PPV_ARGS(&mfSampleTexture));
     H::System::ThrowIfFailed(hr);
 
-    Microsoft::WRL::ComPtr<ID3D11Texture2D> dstTexture;
-    {
-        H::Dx::MFDXGIDeviceManagerLock mfDxgiDeviceManagerLock{ this->mfDxgiDeviceManager }; // it may block current thread when device lock / unlock
+    Microsoft::WRL::ComPtr<ID3D11Texture2D> sharedDstTexture;
+    H::Dx::MFDXGIDeviceManagerLock mfDxgiDeviceManagerLock{ this->mfDxgiDeviceManager }; // it may block current thread when device lock / unlock
 
-        Microsoft::WRL::ComPtr<ID3D11Device> mfD3dDevice;
-        hr = mfDxgiDeviceManagerLock.LockDevice(mfD3dDevice.GetAddressOf());
-        if (FAILED(hr)) {
-            Dbreak;
-        }
-
-        D3D11_TEXTURE2D_DESC srcTextureDesc = {};
-        mfSampleTexture->GetDesc(&srcTextureDesc);
-
-        if (!this->sharedTexture) {
-            this->sharedTexture = std::make_unique<H::Dx::DxSharedTexture>(srcTextureDesc, this->dxDeviceSafeObj->Lock()->GetD3DDevice(), mfD3dDevice);
-        }
-        this->sharedTexture->CopyTexture(dstTexture.GetAddressOf(), mfSampleTexture);
+    Microsoft::WRL::ComPtr<ID3D11Device> mfD3dDevice;
+    hr = mfDxgiDeviceManagerLock.LockDevice(mfD3dDevice.GetAddressOf());
+    if (FAILED(hr)) {
+        Dbreak;
     }
+
+    D3D11_TEXTURE2D_DESC srcTextureDesc = {};
+    mfSampleTexture->GetDesc(&srcTextureDesc);
+
+    if (!this->sharedTexture) {
+        this->sharedTexture = std::make_unique<H::Dx::DxSharedTexture>(srcTextureDesc, this->dxDeviceSafeObj->Lock()->GetD3DDevice(), mfD3dDevice);
+    }
+
+    // Copy decoded frame into shared keyed texture once per sample
+    this->sharedTexture->WriteToSharedTexture(mfSampleTexture, 0, 1);
+    sharedDstTexture = this->sharedTexture->GetDstTexture();
 
     MF::MFSample mfSampleCopy = *mfSample;
     mfSampleCopy.buffer = nullptr; // release original reference to IMFSample
-    auto sample = std::make_unique<MF::MFVideoSample>(mfSampleCopy, dstTexture);
+    auto sample = std::make_unique<MF::MFVideoSample>(mfSampleCopy, sharedDstTexture);
     return sample;
 
 #else

--- a/VideoPlayer/TestVideoPlayer/Sources/AvReaderDxgiEffect.h
+++ b/VideoPlayer/TestVideoPlayer/Sources/AvReaderDxgiEffect.h
@@ -5,7 +5,7 @@
 #include <Helpers/Dx/DxgiDeviceLock.h>
 #include <Helpers/Dx/DxDevice.h>
 
-#define AvReaderDxgiManager_NEW_LOGIC 0
+#define AvReaderDxgiManager_NEW_LOGIC 1
 
 class AvReaderDxgiEffect : public IAvReaderEffect {
 public:

--- a/VideoPlayer/TestVideoPlayer/Sources/VideoSceneRenderer.cpp
+++ b/VideoPlayer/TestVideoPlayer/Sources/VideoSceneRenderer.cpp
@@ -215,12 +215,33 @@ namespace TestVideoPlayer {
 		if (videoSample) {
 			auto dpiScaleFactor = this->swapChainPanel->GetDpi() / 96.0f;
 
-			// Create a ID2D1Bitmap1 out of the frame texture
-			auto frame = DxTools::CreateFrameBitmap(dxCtx, videoSample->texture);
-			this->scaleEffect->SetInput(0, frame.Get());
+			// Create a ID2D1Bitmap1 out of the frame texture. If the texture is shared via keyed mutex,
+			// lock it for reading instead of copying it to a new resource.
+			Microsoft::WRL::ComPtr<ID3D11Texture2D> frameTexture = videoSample->texture;
+			D3D11_TEXTURE2D_DESC frameDesc{};
+			frameTexture->GetDesc(&frameDesc);
 
-			D3D11_TEXTURE2D_DESC frameDesc;
-			videoSample->texture->GetDesc(&frameDesc);
+			Microsoft::WRL::ComPtr<ID2D1Bitmap1> frame;
+			if (frameDesc.MiscFlags & D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX) {
+				Microsoft::WRL::ComPtr<IDXGIKeyedMutex> keyedMutex;
+				if (SUCCEEDED(frameTexture.As(&keyedMutex))) {
+					// Writer releases with key 1, reader acquires with the same key and releases with 0.
+					HRESULT hr = keyedMutex->AcquireSync(1, 0);
+					if (SUCCEEDED(hr)) {
+						frame = DxTools::CreateFrameBitmap(dxCtx, frameTexture);
+						keyedMutex->ReleaseSync(0);
+					}
+				}
+			}
+			else {
+				frame = DxTools::CreateFrameBitmap(dxCtx, frameTexture);
+			}
+
+			if (!frame) {
+				return;
+			}
+
+			this->scaleEffect->SetInput(0, frame.Get());
 
 			// Scale the frame keeping aspect ratio
 			auto renderTargetSize = this->swapChainPanel->GetRenderTargetSize();

--- a/VideoPlayer/TestVideoPlayer/Sources/VideoSceneRenderer.cpp
+++ b/VideoPlayer/TestVideoPlayer/Sources/VideoSceneRenderer.cpp
@@ -216,21 +216,21 @@ namespace TestVideoPlayer {
 			auto dpiScaleFactor = this->swapChainPanel->GetDpi() / 96.0f;
 
 			// Create a ID2D1Bitmap1 out of the frame texture. If the texture is shared via keyed mutex,
-			// lock it for reading instead of copying it to a new resource.
+			// lock it for reading instead of copying it to a new resource and keep the lock until after DrawImage.
 			Microsoft::WRL::ComPtr<ID3D11Texture2D> frameTexture = videoSample->texture;
 			D3D11_TEXTURE2D_DESC frameDesc{};
 			frameTexture->GetDesc(&frameDesc);
 
 			Microsoft::WRL::ComPtr<ID2D1Bitmap1> frame;
-			if (frameDesc.MiscFlags & D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX) {
-				Microsoft::WRL::ComPtr<IDXGIKeyedMutex> keyedMutex;
-				if (SUCCEEDED(frameTexture.As(&keyedMutex))) {
-					// Writer releases with key 1, reader acquires with the same key and releases with 0.
-					HRESULT hr = keyedMutex->AcquireSync(1, 0);
-					if (SUCCEEDED(hr)) {
-						frame = DxTools::CreateFrameBitmap(dxCtx, frameTexture);
-						keyedMutex->ReleaseSync(0);
-					}
+			Microsoft::WRL::ComPtr<IDXGIKeyedMutex> keyedMutex;
+			bool frameLocked = false;
+
+			if (frameDesc.MiscFlags & D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX && SUCCEEDED(frameTexture.As(&keyedMutex))) {
+				// Writer releases with key 1, reader acquires with the same key and releases with 0.
+				HRESULT hr = keyedMutex->AcquireSync(1, INFINITE);
+				if (SUCCEEDED(hr)) {
+					frame = DxTools::CreateFrameBitmap(dxCtx, frameTexture);
+					frameLocked = true;
 				}
 			}
 			else {
@@ -238,6 +238,9 @@ namespace TestVideoPlayer {
 			}
 
 			if (!frame) {
+				if (frameLocked && keyedMutex) {
+					keyedMutex->ReleaseSync(0);
+				}
 				return;
 			}
 
@@ -271,6 +274,10 @@ namespace TestVideoPlayer {
 			this->centerEffect->SetValue(D2D1_2DAFFINETRANSFORM_PROP_TRANSFORM_MATRIX, matrix);
 
 			d2dCtx->DrawImage(this->centerEffect.Get());
+
+			if (frameLocked && keyedMutex) {
+				keyedMutex->ReleaseSync(0);
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- enable the new DXGI path so decoded frames stay in shared keyed textures
- write frames once into a shared texture and render directly from it without per-frame copies
- adjust renderer to lock keyed mutex textures when drawing and add keyed-lock helpers for shared textures

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69458d150bd48322bc8c59f2e08ffdb7)